### PR TITLE
Added additional output of fractional turns as well as degrees

### DIFF
--- a/g81_relative.rb
+++ b/g81_relative.rb
@@ -16,18 +16,40 @@
 #  David Hagege <david.hagege@gmail.com>
 
 class G81Relative
+  def self.convertDistanceToFractionalTurns(distance)
+    screw_pitch = 0.5
+    return Rational(distance/screw_pitch).round(+1)
+  end
+  def self.convertDistanceToDegrees(distance)
+    screw_pitch = 0.5
+    return "#{(distance/screw_pitch*360).round}"+"°"
+  end
   def self.g81_relative(content)
     points = content.lines.select{|x| x =~ /Recv:/}.join("\n").gsub(/Recv:\s/, '').split(' ').map(&:to_f)
 
     center = points[24]
     top_left, top_middle, top_right, middle_left,
       middle_right, bottom_left,
-      bottom_center, bottom_right = points.values_at(0,3,6,21,27,42,45,48).map{|x| (x - center).round(3)}
+      bottom_center, bottom_right = points.values_at(0,3,6,21,27,42,45,48).map{|x| (x - center).round(2)}
 
+
+    puts "Raw Values:"
+    puts %Q{
+          #{top_left}\t#{top_middle}\t#{top_right}
+          #{middle_left}\t0\t#{middle_right}
+          #{bottom_left}\t#{bottom_center}\t#{bottom_right}
+        }
+    puts "Degrees:"
+    puts %Q{
+      #{convertDistanceToDegrees(top_left)}\t#{convertDistanceToDegrees(top_middle)}\t#{convertDistanceToDegrees(top_right)}
+      #{convertDistanceToDegrees(middle_left)}\t0\t#{convertDistanceToDegrees(middle_right)}
+      #{convertDistanceToDegrees(bottom_left)}\t#{convertDistanceToDegrees(bottom_center)}\t#{convertDistanceToDegrees(bottom_right)}
+    }
+    puts "Fractional Turns:"
     %Q{
-      #{top_left}\t#{top_middle}\t#{top_right}
-      #{middle_left}\t0\t#{middle_right}
-      #{bottom_left}\t#{bottom_center}\t#{bottom_right}
+      #{convertDistanceToFractionalTurns(top_left)}\t#{convertDistanceToFractionalTurns(top_middle)}\t#{convertDistanceToFractionalTurns(top_right)}
+      #{convertDistanceToFractionalTurns(middle_left)}\t0\t#{convertDistanceToFractionalTurns(middle_right)}
+      #{convertDistanceToFractionalTurns(bottom_left)}\t#{convertDistanceToFractionalTurns(bottom_center)}\t#{convertDistanceToFractionalTurns(bottom_right)}
     }
   end
 end


### PR DESCRIPTION
When I was leveling my bed, I found it less confusing depending on how far I needed to go to see distance to go as well as fractional turns (1/4 turn left) and, in the case of very small adjustment, degrees.  This pull request outputs all three one after the other.